### PR TITLE
Add replaces for ConfigurableCommitTicketUpdater

### DIFF
--- a/conf/trac.ini
+++ b/conf/trac.ini
@@ -271,6 +271,12 @@ preserve_newlines = default
 restrict_owner = false
 workflow = ConfigurableTicketWorkflow
 
+[commit-ticket-update-replace]
+ticket.pattern = https?\://trac\.macports\.org/ticket/(\d+)
+ticket.replace = #\1
+pullreq.pattern = (\s)#(\d+)
+pullreq.replace = \1https://github.com/macports/$(repository)s/pull/\2
+
 [ticket-custom]
 port = text
 port.format = list


### PR DESCRIPTION
This is the configuration for MacPorts for a new feature submitted to the trac-configurable-ctu.

https://github.com/neverpanic/trac-configurable-ctu/pull/2