### PR TITLE
Fix changelog color in css.sty

### DIFF
--- a/htdocs/style.css
+++ b/htdocs/style.css
@@ -44,6 +44,12 @@ h4 :link, h4 :visited, h5 :link, h5 :visited, h6 :link, h6 :visited {
     max-width: 100%;
 }
 
+/* changelog box colors */
+#changelog .changes {
+    background-color: #eee;
+    border-color: #d7d7d7;
+}
+
 /* tickets: colors */
 #ticket {
     background-color: #eee;


### PR DESCRIPTION
Here's my proposed change for the css.

We might additionally want to change something like
```css
h1:target, h2:target, h3:target, h4:target, h5:target, h6:target, span:target {
    background: #cddffa; /* color for testing only, shadow color needs to be adapted as well */
}
```
and maybe
```css
#changelog .comment, #ticketchange .comment {
    clear: right;
}
```